### PR TITLE
add transaction option type

### DIFF
--- a/lib/arangox.ex
+++ b/lib/arangox.ex
@@ -47,6 +47,13 @@ defmodule Arangox do
           | {:client_opts, :gun.opts() | keyword()}
           | DBConnection.start_option()
 
+  @type transaction_option ::
+          {:read, binary() | [binary()]}
+          | {:write, binary() | [binary()]}
+          | {:exclusive, binary() | [binary()]}
+          | {:properties, list() | map()}
+          | DBConnection.option()
+
   @doc """
   Returns a supervisor child specification for a DBConnection pool.
   """
@@ -336,7 +343,7 @@ defmodule Arangox do
         properties: [waitForSync: true]
       ])
   """
-  @spec transaction(conn, (DBConnection.t() -> result), [DBConnection.option()]) ::
+  @spec transaction(conn, (DBConnection.t() -> result), [transaction_option()]) ::
           {:ok, result} | {:error, any}
         when result: var
   defdelegate transaction(conn, fun, opts \\ []), to: DBConnection


### PR DESCRIPTION
This fixes the warning from dialyzer.

```
The function call will not succeed.

Arangox.transaction(_conn :: any(), (_ -> any()), [
  {:write, <<117, 115, 101, 114, 115>>},
  {:properties, [{:waitForSync, true}]}
])

breaks the contract
(conn(), (DBConnection.t() -> :result), [DBConnection.option()]) ::
  {:ok, :result} | {:error, any()}
```