### PR TITLE
Add the :database option for transactions and cursors

### DIFF
--- a/lib/arangox.ex
+++ b/lib/arangox.ex
@@ -327,6 +327,7 @@ defmodule Arangox do
     * `:read` - An array of collection names or a single collection name as a binary.
     * `:write` - An array of collection names or a single collection name as a binary.
     * `:exclusive` - An array of collection names or a single collection name as a binary.
+    * `:database` - Sets what database to run the transaction on
     * `:properties` - A list or map of additional body attributes to append to the request
     body when beginning a transaction.
 
@@ -387,6 +388,7 @@ defmodule Arangox do
   Accepts any of the options accepted by `DBConnection.stream/4`, as well as any of the
   following:
 
+    * `:database` - Sets what database to run the cursor query on
     * `:properties` - A list or map of additional body attributes to append to the
     request body when creating the cursor.
 


### PR DESCRIPTION
If you want to be able to call a transaction or cursor against a different database than what the connection was opened on this was not possible. This change simply adds the `:database` option to the Arangox.transaction/3 and Arangox.cursor/4 functions. When the DBConnection stream calls back to Arangox the `:database` option is used to prepend the to uri path.

This PR is required for a feature in the `arangox_ecto` package that uses this one, more info here: https://github.com/TomGrozev/arangox_ecto/issues/25